### PR TITLE
Fixed typo in options.lua and README.MD for rust config (missing slas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ require('code_runner').setup({
     rust = {
       "cd $dir &&",
       "rustc $fileName &&",
-      "$dir$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt"
     },
   },
 })
@@ -221,7 +221,7 @@ require('code_runner').setup {
     rust = {
       "cd $dir &&",
       "rustc $fileName &&",
-      "$dir$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt"
     },
   },
   project_path = "", -- No default path defined
@@ -250,7 +250,7 @@ require('code_runner').setup {
         rust = {
           "cd $dir &&",
           "rustc $fileName &&",
-          "$dir$fileNameWithoutExt"
+          "$dir/$fileNameWithoutExt"
         },
 	},
 	project = {
@@ -301,7 +301,7 @@ The file should look like this(the default file does not exist create it with th
     rust = {
       "cd $dir &&",
       "rustc $fileName &&",
-      "$dir$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt"
     },
 },
 ..... more config .....

--- a/lua/code_runner/options.lua
+++ b/lua/code_runner/options.lua
@@ -40,26 +40,26 @@ local options = {
     java = {
       "cd $dir &&",
       "javac $fileName &&",
-      "java $fileNameWithoutExt"
+      "java $fileNameWithoutExt",
     },
     c = {
       "cd $dir &&",
       "gcc $fileName",
       "-o $fileNameWithoutExt &&",
-      "$dir/$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt",
     },
     cpp = {
       "cd $dir &&",
       "g++ $fileName",
       "-o $fileNameWithoutExt &&",
-      "$dir/$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt",
     },
     python = "python -u",
     sh = "bash",
     rust = {
       "cd $dir &&",
       "rustc $fileName &&",
-      "$dir$fileNameWithoutExt"
+      "$dir/$fileNameWithoutExt",
     },
   },
   project_path = "",
@@ -70,7 +70,7 @@ local options = {
 local M = {}
 
 local function concat(v)
-  if type(v) == 'table' then
+  if type(v) == "table" then
     return table.concat(v, " ")
   end
   return v


### PR DESCRIPTION
…h in executing script)